### PR TITLE
Fix types of mergeObjectValuesBy

### DIFF
--- a/.changeset/honest-parents-fetch.md
+++ b/.changeset/honest-parents-fetch.md
@@ -1,0 +1,5 @@
+---
+"@giraugh/tools": patch
+---
+
+Fix type of TOBJ in mergeObjectValuesBy being unuseable with interfaces

--- a/lib/objects/mergeObjectValuesBy.ts
+++ b/lib/objects/mergeObjectValuesBy.ts
@@ -9,7 +9,7 @@
  */
 export const mergeObjectValuesBy = <
   TKeys extends PropertyKey,
-  TObj extends Record<TKeys, unknown>
+  TObj extends Record<TKeys, any>
 >(
   objects: TObj[],
   mergeFn: (a: TObj[TKeys], b: TObj[TKeys]) => TObj[TKeys]


### PR DESCRIPTION
Changes the type of `TObj` in `mergeObjectValuesBy` to allow use with interfaces