### PR TITLE
Add a settleObject util

### DIFF
--- a/.changeset/lucky-snakes-flow.md
+++ b/.changeset/lucky-snakes-flow.md
@@ -1,0 +1,5 @@
+---
+"@giraugh/tools": minor
+---
+
+Add a `settleObject` util that behaves like Promise.allSettled for objects

--- a/.changeset/modern-doors-melt.md
+++ b/.changeset/modern-doors-melt.md
@@ -1,0 +1,5 @@
+---
+"@giraugh/tools": patch
+---
+
+Allow `resolveObject` to take a `number` or `symbol` as a key

--- a/lib/promises/index.ts
+++ b/lib/promises/index.ts
@@ -1,3 +1,4 @@
 export * from './filterAsync'
 export * from './mapAsync'
 export * from './resolveObject'
+export * from './settleObject'

--- a/lib/promises/resolveObject.ts
+++ b/lib/promises/resolveObject.ts
@@ -2,27 +2,29 @@ export type Resolved<Type> = { [k in keyof Type]: Awaited<Type[k]> }
 
 /**
  * Resolve all of the fields of an object in parallel
- * @param object An object where every field is a promise 
+ * @param object An object where every field is a promise
  * @returns The same object with every field resolved
- * 
+ *
  * @example await resolveObject({
  *   a: Promise.resolve('a'),
- *   b: Promise.resolve('b'), 
+ *   b: Promise.resolve('b'),
  * }) === { a: 'a', b: 'b' }
  *
  * @example await resolveObject({
  *   a: Promise.resolve('a'),
- *   b: Promise.reject('b'), 
+ *   b: Promise.reject('b'),
  * }) // throws error
+ *
+ * @see {@link settleObject} if you don't want to fail if some promises reject
  */
-export const resolveObject = async <T extends Record<string, Promise<any>>>(object: T): Promise<Resolved<T>> => {
-  // Create promises for each entry 
+export const resolveObject = async <T extends Record<PropertyKey, Promise<any>>>(object: T): Promise<Resolved<T>> => {
+  // Create promises for each entry
   const entryPromises = Object.entries(object)
     .map(([key, promise]) => promise.then(value => [key, value]))
-  
+
   // Resolve the promises
   const resolvedEntries = await Promise.all(entryPromises)
-  
+
   // Reconstruct object
   return Object.fromEntries(resolvedEntries)
 }

--- a/lib/promises/settleObject.ts
+++ b/lib/promises/settleObject.ts
@@ -1,0 +1,61 @@
+/**
+ * Settle all of the fields of an object in parallel
+ * @param object An object where every field is a promise
+ * @returns The same object with every field settled
+ *
+ * @example await settleObject({
+ *   a: Promise.resolve('a'),
+ *   b: Promise.resolve('b'),
+ * }) === {
+ *   a: { status: 'fulfilled', value: 'a' },
+ *   b: { status: 'fulfilled', value: 'b' },
+ * }
+ *
+ * @example await settleObject({
+ *   a: Promise.resolve('a'),
+ *   b: Promise.reject('b'),
+ * }) === {
+ *   a: { status: 'fulfilled', value: 'a' },
+ *   b: { status: 'rejected', reason: 'b' },
+ * }
+ *
+ * @see {@link resolveObject} if you want to fail on any promise rejection
+ */
+export const settleObject = async <T extends Record<PropertyKey, Promise<unknown>>>(object: T): Promise<{ [k in keyof T]: PromiseSettledResult<T[k]> }> => {
+  // Turn into entries
+  const entries = Object.entries(object)
+
+  // Settle the promises
+  const settledValues = await Promise.allSettled(entries.map(e => e[1]))
+
+  // Match keys with settled values
+  const settledEntries = settledValues.map((v, i) => [entries[i][0], v] as const)
+
+  // Reconstruct object
+  return Object.fromEntries(settledEntries) as { [k in keyof T]: PromiseSettledResult<T[k]> }
+}
+
+// Tests
+if (import.meta.vitest) {
+  const { it, expect } = import.meta.vitest
+
+  it('works for example 1', () => {
+    expect(settleObject({
+      a: Promise.resolve('a'),
+      b: Promise.resolve('b'),
+    })).resolves.toStrictEqual({
+      a: { status: 'fulfilled', value: 'a' },
+      b: { status: 'fulfilled', value: 'b' },
+    })
+  })
+
+  it('works for example 2', () => {
+    expect(settleObject({
+      a: Promise.resolve('a'),
+      b: Promise.reject('b'),
+    })).resolves.toStrictEqual({
+      a: { status: 'fulfilled', value: 'a' },
+      b: { status: 'rejected', reason: 'b' },
+    })
+  })
+}


### PR DESCRIPTION
Add a `settleObject` util that behaves like Promise.allSettled for objects.

Use like so:

```ts
await settleObject({
  a: Promise.resolve('a'),
  b: Promise.reject('b'),
}) === {
  a: { status: 'fulfilled', value: 'a' },
  b: { status: 'rejected', reason: 'b' },
}
```

Also allows the `resolveObject` util to accept a `number` or `symbol` as a key.